### PR TITLE
Fixed Additional Properties Render

### DIFF
--- a/packages/api-reference/src/components/Content/Schema/Schema.vue
+++ b/packages/api-reference/src/components/Content/Schema/Schema.vue
@@ -233,7 +233,7 @@ const handleDiscriminatorChange = (type: string) => {
         </DisclosureButton>
         <DisclosurePanel
           as="ul"
-          :static="!shouldShowToggle">
+          :static="!shouldShowToggle && !additionalProperties">
           <!-- Schema properties -->
           <template
             v-if="


### PR DESCRIPTION
The "additional properties" button used to appear alongside every property rendering all at once. The issue was to do with the DisclosurePanel's static field evaluated to true, thus disregarding the hiding functionality for the additional properties. This is the more straightforward approach to solving this issue without doing large refactors on template logic; the DisclosurePanel logic was flawed.

Before:
<img width="864" height="620" alt="Screenshot 2025-10-19 at 11 19 21 PM" src="https://github.com/user-attachments/assets/e3cb4396-99b9-4ffb-892c-c3b877e82146" />

After: 
<img width="590" height="567" alt="Screenshot 2025-10-20 at 8 57 16 AM" src="https://github.com/user-attachments/assets/7b4fae2c-3fda-4f7d-9c30-6fe578effc80" />

Demo: [Youtube Video Demo](https://youtu.be/lR9-cFYEPZw?si=xX2r_q9VTQwaPGl6)


Resolves #12 