### PR TITLE
Replace btoa/atob with js-base64 encoding

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -224,6 +224,7 @@
     "@vueuse/integrations": "catalog:*",
     "focus-trap": "^7",
     "fuse.js": "^7.0.0",
+    "js-base64": "^3.7.8",
     "microdiff": "^1.4.0",
     "nanoid": "catalog:*",
     "pretty-bytes": "^6.1.1",

--- a/packages/api-client/src/libs/parse-curl.ts
+++ b/packages/api-client/src/libs/parse-curl.ts
@@ -1,5 +1,6 @@
 import type { RequestMethod } from '@scalar/oas-utils/entities/spec'
 import { parse as parseShellCommand } from 'shell-quote'
+import { Base64 } from 'js-base64'
 
 /** Parse and normalize a curl command */
 export function parseCurlCommand(curlCommand: string) {
@@ -140,7 +141,7 @@ function parseAuth(iterator: Iterator<string>, result: any) {
   const auth = iterator.next().value
 
   try {
-    const encodedAuth = btoa(auth)
+    const encodedAuth = Base64.encode(auth)
 
     result.headers = result.headers || {}
 

--- a/packages/api-client/src/libs/send-request/build-request-security.test.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.test.ts
@@ -1,4 +1,5 @@
-import { type SecurityScheme, securitySchemeSchema } from '@scalar/oas-utils/entities/spec'
+import { securitySchemeSchema, type SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import { Base64 } from 'js-base64'
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { buildRequestSecurity } from './build-request-security'
@@ -71,7 +72,7 @@ describe('buildRequestSecurity', () => {
     it('should handle basic auth', () => {
       basic.scheme = 'basic'
       const result = buildRequestSecurity([basic])
-      expect(result.headers['Authorization']).toBe(`Basic ${btoa('scalar:user')}`)
+      expect(result.headers['Authorization']).toBe(`Basic ${Base64.encode('scalar:user')}`)
     })
 
     it('should handle basic auth with empty credentials', () => {
@@ -79,6 +80,13 @@ describe('buildRequestSecurity', () => {
       basic.password = ''
       const result = buildRequestSecurity([basic])
       expect(result.headers['Authorization']).toBe('Basic username:password')
+    })
+
+    it('should handle basic auth with non-Latin1 Unicode credentials', () => {
+      basic.username = 'üsér🔐'
+      basic.password = 'päss🗝️wörd'
+      const result = buildRequestSecurity([basic])
+      expect(result.headers['Authorization']).toBe(`Basic ${Base64.encode('üsér🔐:päss🗝️wörd')}`)
     })
 
     it('should handle bearer auth', () => {

--- a/packages/api-client/src/libs/send-request/build-request-security.ts
+++ b/packages/api-client/src/libs/send-request/build-request-security.ts
@@ -2,6 +2,7 @@ import { replaceTemplateVariables } from '@/libs/string-template'
 import { cookieSchema, type Cookie } from '@scalar/oas-utils/entities/cookie'
 import type { SecurityScheme } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
+import { Base64 } from 'js-base64'
 
 /**
  * Generates the headers, cookies and query params for selected security schemes
@@ -46,7 +47,7 @@ export const buildRequestSecurity = (
         const password = replaceTemplateVariables(scheme.password, env)
         const value = `${username}:${password}`
 
-        headers['Authorization'] = `Basic ${value === ':' ? 'username:password' : btoa(value)}`
+        headers['Authorization'] = `Basic ${value === ':' ? 'username:password' : Base64.encode(value)}`
       } else {
         const value = replaceTemplateVariables(scheme.token, env)
         headers['Authorization'] = `Bearer ${value || emptyTokenPlaceholder}`

--- a/packages/api-client/src/libs/send-request/create-request-operation.test.ts
+++ b/packages/api-client/src/libs/send-request/create-request-operation.test.ts
@@ -14,6 +14,8 @@ import type { SelectedSecuritySchemeUids } from '@scalar/oas-utils/entities/shar
 import * as electron from '../electron'
 import { createRequestOperation } from './create-request-operation'
 
+import { Base64 } from 'js-base64'
+
 const PROXY_PORT = 5051
 const VOID_PORT = 5052
 const PROXY_URL = `http://127.0.0.1:${PROXY_PORT}`
@@ -967,7 +969,7 @@ describe('create-request-operation', () => {
         throw new Error('No data')
       }
       expect(JSON.parse(result?.response.data as string).headers).toMatchObject({
-        authorization: `Basic ${btoa('user:pass')}`,
+        authorization: `Basic ${Base64.encode('user:pass')}`,
       })
     })
 

--- a/packages/api-client/src/views/Components/CodeSnippet/CodeSnippet.vue
+++ b/packages/api-client/src/views/Components/CodeSnippet/CodeSnippet.vue
@@ -8,6 +8,7 @@ import type {
 } from '@scalar/oas-utils/entities/spec'
 import { isDefined } from '@scalar/oas-utils/helpers'
 import type { ClientId, TargetId } from '@scalar/snippetz'
+import { Base64 } from 'js-base64'
 import { computed } from 'vue'
 
 import type { EnvVariables } from '@/libs/env-helpers'
@@ -41,7 +42,7 @@ const secretCredentials = computed(() =>
       return [
         scheme.token,
         scheme.password,
-        btoa(`${scheme.username}:${scheme.password}`),
+        Base64.encode(`${scheme.username}:${scheme.password}`),
       ]
     }
     if (scheme.type === 'oauth2') {

--- a/packages/api-client/src/views/Request/libs/oauth2.test.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.test.ts
@@ -3,6 +3,7 @@ import { flushPromises } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { authorizeOauth2 } from './oauth2'
+import { Base64 } from 'js-base64'
 
 const baseScheme = {
   uid: 'test-scheme',
@@ -25,7 +26,7 @@ const authorizationUrl = 'https://auth.example.com/authorize'
 const tokenUrl = 'https://auth.example.com/token'
 const redirectUri = 'https://callback.example.com'
 const clientSecret = 'yyyyy'
-const secretAuth = btoa(`${baseFlow['x-scalar-client-id']}:${clientSecret}`)
+const secretAuth = Base64.encode(`${baseFlow['x-scalar-client-id']}:${clientSecret}`)
 
 const windowTarget = 'openAuth2Window'
 const windowFeatures = 'left=100,top=100,width=800,height=600'

--- a/packages/api-client/src/views/Request/libs/oauth2.ts
+++ b/packages/api-client/src/views/Request/libs/oauth2.ts
@@ -1,6 +1,8 @@
-import type { ErrorResponse } from '@/libs/errors'
 import type { Oauth2Flow, Server } from '@scalar/oas-utils/entities/spec'
 import { shouldUseProxy } from '@scalar/oas-utils/helpers'
+import { Base64 } from 'js-base64'
+
+import type { ErrorResponse } from '@/libs/errors'
 
 /** Oauth2 security schemes which are not implicit */
 type NonImplicitFlow = Exclude<Oauth2Flow, { type: 'implicit' }>
@@ -22,10 +24,7 @@ const generateCodeVerifier = (): string => {
   crypto.getRandomValues(buffer)
 
   // Base64URL encode the bytes
-  return btoa(String.fromCharCode(...buffer))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '')
+  return Base64.encode(String.fromCharCode(...buffer), true)
 }
 
 /**
@@ -42,10 +41,7 @@ export const generateCodeChallenge = async (verifier: string, encoding: 'SHA-256
   const digest = await crypto.subtle.digest('SHA-256', data)
 
   // Base64URL encode the bytes
-  return btoa(String.fromCharCode(...new Uint8Array(digest)))
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=+$/, '')
+  return Base64.encode(String.fromCharCode(...new Uint8Array(digest)), true)
 }
 
 /**
@@ -282,7 +278,7 @@ export const authorizeServers = async (
 
     // Add client id + secret to headers
     if (flow.clientSecret) {
-      headers.Authorization = `Basic ${btoa(`${flow['x-scalar-client-id']}:${flow.clientSecret}`)}`
+      headers.Authorization = `Basic ${Base64.encode(`${flow['x-scalar-client-id']}:${flow.clientSecret}`)}`
     }
 
     // Check if we should use the proxy

--- a/packages/api-reference/package.json
+++ b/packages/api-reference/package.json
@@ -81,6 +81,7 @@
     "flatted": "^3.3.1",
     "fuse.js": "^7.0.0",
     "github-slugger": "^2.0.0",
+    "js-base64": "^3.7.8",
     "microdiff": "^1.4.0",
     "nanoid": "catalog:*",
     "vue": "catalog:*",

--- a/packages/api-reference/src/features/example-request/ExampleRequest.vue
+++ b/packages/api-reference/src/features/example-request/ExampleRequest.vue
@@ -17,6 +17,7 @@ import {
 import { isDereferenced } from '@scalar/openapi-types/helpers'
 import type { ClientId, TargetId } from '@scalar/snippetz'
 import type { OpenAPIV3_1 } from '@scalar/types/legacy'
+import { Base64 } from 'js-base64'
 import {
   computed,
   inject,
@@ -244,7 +245,7 @@ const secretCredentials = computed(() =>
       return [
         scheme.token,
         scheme.password,
-        btoa(`${scheme.username}:${scheme.password}`),
+        Base64.encode(`${scheme.username}:${scheme.password}`),
       ]
     }
     if (scheme.type === 'oauth2') {

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/get-secrets.test.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/get-secrets.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import type { SecuritySchemeObject } from '@scalar/workspace-store/schemas/v3.1/strict/security-scheme'
 
+import { Base64 } from 'js-base64'
+
 import { getSecrets } from './get-secrets'
 
 describe('getSecrets', () => {
@@ -349,7 +351,7 @@ describe('getSecrets', () => {
       expect(result[2]).toBe('YWRtaW46c2VjcmV0MTIz') // base64 encoded "admin:secret123"
 
       // Verify we can decode it back
-      const decoded = atob(result[2])
+      const decoded = Base64.decode(result[2])
       expect(decoded).toBe('admin:secret123')
     })
 
@@ -369,7 +371,7 @@ describe('getSecrets', () => {
       expect(result[2]).toBe('dXNlckBkb21haW4uY29tOnBhc3M6d29yZCE=') // base64 encoded "user@domain.com:pass:word!"
 
       // Verify we can decode it back
-      const decoded = atob(result[2])
+      const decoded = Base64.decode(result[2])
       expect(decoded).toBe('user@domain.com:pass:word!')
     })
   })

--- a/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/get-secrets.ts
+++ b/packages/api-reference/src/v2/blocks/scalar-request-example-block/helpers/get-secrets.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '@scalar/helpers/array/is-defined'
 import type { SecuritySchemeObject } from '@scalar/workspace-store/schemas/v3.1/strict/security-scheme'
+import { Base64 } from 'js-base64'
 
 /** Extract secrets from security schemes */
 export const getSecrets = (securitySchemes: SecuritySchemeObject[]) =>
@@ -13,7 +14,7 @@ export const getSecrets = (securitySchemes: SecuritySchemeObject[]) =>
           scheme['x-scalar-secret-token'],
           scheme['x-scalar-secret-username'],
           scheme['x-scalar-secret-password'],
-          btoa(`${scheme['x-scalar-secret-username']}:${scheme['x-scalar-secret-password']}`),
+          Base64.encode(`${scheme['x-scalar-secret-username']}:${scheme['x-scalar-secret-password']}`),
         ]
       }
       if (scheme.type === 'oauth2') {

--- a/packages/void-server/package.json
+++ b/packages/void-server/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "@hono/node-server": "^1.11.0",
     "hono": "^4.6.5",
+    "js-base64": "^3.7.8",
     "object-to-xml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/void-server/src/utils/getRequestData.ts
+++ b/packages/void-server/src/utils/getRequestData.ts
@@ -1,6 +1,8 @@
 import type { Context } from 'hono'
 import { getCookie } from 'hono/cookie'
 
+import { Base64 } from 'js-base64'
+
 import { getBody } from './getBody'
 
 /**
@@ -21,7 +23,7 @@ export async function getRequestData(c: Context) {
           authentication: {
             type: 'http.basic',
             token,
-            value: atob(token),
+            value: Base64.decode(token),
           },
         }
       }

--- a/packages/workspace-store/package.json
+++ b/packages/workspace-store/package.json
@@ -25,12 +25,12 @@
     "dev": "vite-node ./src/index.ts",
     "format": "scalar-format",
     "format:check": "scalar-format-check",
+    "generate-json-schemas": "vite-node ./scripts/generate-json-schemas.ts",
     "lint:check": "eslint .",
     "lint:fix": "eslint .  --fix",
     "test": "vitest",
     "types:build": "scalar-types-build",
-    "types:check": "scalar-types-check",
-    "generate-json-schemas": "vite-node ./scripts/generate-json-schemas.ts"
+    "types:check": "scalar-types-check"
   },
   "type": "module",
   "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1133,6 +1133,9 @@ importers:
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
+      js-base64:
+        specifier: ^3.7.8
+        version: 3.7.8
       microdiff:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1309,6 +1312,9 @@ importers:
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
+      js-base64:
+        specifier: ^3.7.8
+        version: 3.7.8
       microdiff:
         specifier: ^1.4.0
         version: 1.4.0
@@ -2526,6 +2532,9 @@ importers:
       hono:
         specifier: ^4.6.5
         version: 4.6.5
+      js-base64:
+        specifier: ^3.7.8
+        version: 3.7.8
       object-to-xml:
         specifier: ^2.0.0
         version: 2.0.0
@@ -12434,6 +12443,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}


### PR DESCRIPTION
This commit replaces the JavaScript btoa() Base64 encoding function with
 js-base64's encode() function. The js-base64 function supports encoding
 non-Latin1 Unicode characters into Base64, thereby increasing
accessibility for user credentials. This change affects both BasicAuthentication and OAuth2, which both used the built-in btoa() and atob() functions that do not support non-Latin1 Unicode characters. Additionally, a test case for non-Latin1 Unicode characters in user credentials was added to ensure that the accessibility changes are maintained going forward.

Before: 
<img width="1394" height="613" alt="ScalarIssue7Pre" src="https://github.com/user-attachments/assets/372354a4-437c-4468-891e-70acc4e3d37e" />


After: 
<img width="1107" height="659" alt="ScalarIssue7Post" src="https://github.com/user-attachments/assets/5ac39db2-21cf-4cbb-bda0-7896a0d158e3" />


Video Demo/Code Review: [Demo](https://youtu.be/SXw5PS1UZg8?si=KERUNbA1-3FazUzD)

Resolves: #10 
