### PR TITLE
Enforce color theme and add initial config logic

### DIFF
--- a/packages/api-reference/src/components/ApiReferenceLayout.vue
+++ b/packages/api-reference/src/components/ApiReferenceLayout.vue
@@ -66,6 +66,7 @@ const {
   configuration: providedConfiguration,
   originalDocument: providedOriginalDocument,
   dereferencedDocument: providedDereferencedDocument,
+  isDark,
 } = defineProps<ReferenceLayoutProps>()
 
 defineEmits<{
@@ -79,6 +80,24 @@ defineEmits<{
 const configuration = computed(() =>
   apiReferenceConfigurationSchema.parse(providedConfiguration),
 )
+
+// If isDark doesn't exist, will use the useColorMode sequence to define initial config
+const darkModeState = computed(() => {
+  // Use explicit prop if provided
+  if (isDark !== undefined) return isDark
+
+  // Check stored user preference
+  const stored = localStorage?.getItem('colorMode')
+  if (stored) return stored === 'dark'
+
+  // Fall back to system preference
+  return window?.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
+})
+
+const effectiveDarkMode = computed(() => {
+  const result = isDark ?? darkModeState.value
+  return result
+})
 
 // Configure Reference toasts to use vue-sonner
 const { initializeToasts, toast } = useToasts()
@@ -422,7 +441,7 @@ watch(hash, (newHash, oldHash) => {
                   <template #toggle>
                     <ScalarColorModeToggleButton
                       v-if="!configuration.hideDarkModeToggle"
-                      :modelValue="isDark"
+                      :modelValue="effectiveDarkMode"
                       @update:modelValue="$emit('toggleDarkMode')" />
                     <span v-else />
                   </template>
@@ -472,7 +491,7 @@ watch(hash, (newHash, oldHash) => {
                   <ScalarColorModeToggleIcon
                     v-if="!configuration.hideDarkModeToggle"
                     class="text-c-2 hover:text-c-1"
-                    :mode="isDark ? 'dark' : 'light'"
+                    :mode="effectiveDarkMode ? 'dark' : 'light'"
                     style="transform: scale(1.4)"
                     variant="icon"
                     @click="$emit('toggleDarkMode')" />

--- a/packages/api-reference/src/types.ts
+++ b/packages/api-reference/src/types.ts
@@ -30,7 +30,7 @@ export type ReferenceLayoutProps = {
    * The raw OpenAPI document. Doesn't have to be OpenAPI 3.1.
    */
   originalDocument?: string
-  isDark: boolean
+  isDark?: boolean
   /**
    * @deprecated We can't use this anymore. Use `dereferencedDocument` instead.
    */

--- a/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
+++ b/packages/api-reference/src/v2/ApiReferenceWorkspace.vue
@@ -194,9 +194,17 @@ onCustomEvent(root, 'scalar-update-active-document', (event) => {
 // TODO: persistence should be hoisted into standalone
 // Client side integrations will want to handle dark mode externally
 const { toggleColorMode, isDarkMode } = useColorMode({
-  initialColorMode: selectedConfiguration.value.darkMode ? 'dark' : undefined,
+  initialColorMode:
+    selectedConfiguration.value.darkMode === true
+      ? 'dark'
+      : selectedConfiguration.value.darkMode === false
+        ? 'light'
+        : undefined,
   overrideColorMode: selectedConfiguration.value.forceDarkModeState,
 })
+
+// Always sync store to match useColorMode's determination
+store.update('x-scalar-dark-mode', isDarkMode.value)
 
 /** Update the dark mode state when props change */
 watch(


### PR DESCRIPTION
Logic was added to enforce a consistent color theming layout based upon useColorMode fallbacks. If darkMode is not provided, then look at localStorage for the theme, and if that isn't present either, look at browser preferences. The reason this was added is to enforce consistency and clearly define what theme will be used each time a developer loads the API reference. Some updates were made to the buttons as well to make certain that their visual state matches the visual theme of the page, i.e. if it is dark, then the toggle shows the moon, and light is the sun icon.

Before:
<img width="1440" height="346" alt="ScalarIssue11Pre" src="https://github.com/user-attachments/assets/afd68a08-94f9-4e4d-9f6c-34daafc7f13b" />

After:
- With darkMode set to false:
<img width="1440" height="528" alt="ScalarIssue11PostLightMode" src="https://github.com/user-attachments/assets/42a03845-e641-486a-b466-1cd1d06a08f5" />

- With darkMode set to true:
<img width="1440" height="543" alt="ScalarIssue11PostDarkMode" src="https://github.com/user-attachments/assets/99c141b8-0e0b-4bf6-a85f-b872d5b35ad1" />

- With no darkMode/undefined:
<img width="1438" height="502" alt="ScalarIssue11PostDefault" src="https://github.com/user-attachments/assets/472814b9-42a4-44a8-ac92-85ac7a09e9bf" />

Demo/Code Review:
[Video Demo](https://youtu.be/FFHfylKtcnY?si=ZQrih3A_uq_zgG2e)

Resolves: #16 