### PR TITLE
Feat/scopes deselect button

### DIFF
--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -50,6 +50,10 @@ function selectAllScopes() {
     Object.keys(flow?.scopes ?? {}),
   )
 }
+
+function deselectAllScopes() {
+  updateScheme(`flows.${flow.type}.selectedScopes`, [])
+}
 </script>
 
 <template>
@@ -82,6 +86,18 @@ function selectAllScopes() {
               size="sm"
               @click.stop="selectAllScopes">
               Select All
+            </ScalarButton>
+
+            <ScalarButton
+              v-if="
+                flow?.selectedScopes?.length > 4 &&
+                open &&
+                flow?.selectedScopes?.length > 0
+              "
+              class="text-c-3 hover:bg-b-2 hover:text-c-1 rounded px-1.5"
+              size="sm"
+              @click.stop="deselectAllScopes">
+              Deselect All
             </ScalarButton>
             <ScalarIcon
               class="text-c-3 group-hover/scopes-accordion:text-c-2"

--- a/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
+++ b/packages/api-client/src/views/Request/RequestSection/RequestAuth/OAuthScopesInput.vue
@@ -27,6 +27,11 @@ const scopes = computed(() =>
 /** An array of the selected scope ids */
 const selectedScopes = computed(() => flow?.selectedScopes || [])
 
+/** Check if all scopes are selected */
+const isAllSelected = computed(
+  () => selectedScopes.value.length === Object.keys(flow?.scopes ?? {}).length,
+)
+
 function setScope(id: string, checked: boolean) {
   // Checked - Add scope to list
   if (checked) {
@@ -54,6 +59,15 @@ function selectAllScopes() {
 function deselectAllScopes() {
   updateScheme(`flows.${flow.type}.selectedScopes`, [])
 }
+
+/** Toggle between select all and deselect all */
+function toggleAllScopes() {
+  if (isAllSelected.value) {
+    deselectAllScopes()
+  } else {
+    selectAllScopes()
+  }
+}
 </script>
 
 <template>
@@ -76,28 +90,11 @@ function deselectAllScopes() {
           </div>
           <div class="flex items-center gap-1.75">
             <ScalarButton
-              v-if="
-                flow?.selectedScopes?.length > 4 &&
-                open &&
-                flow?.selectedScopes?.length <
-                  Object.keys(flow?.scopes ?? {}).length
-              "
+              v-if="flow?.selectedScopes?.length >= 5 && open"
               class="text-c-3 hover:bg-b-2 hover:text-c-1 rounded px-1.5"
               size="sm"
-              @click.stop="selectAllScopes">
-              Select All
-            </ScalarButton>
-
-            <ScalarButton
-              v-if="
-                flow?.selectedScopes?.length > 4 &&
-                open &&
-                flow?.selectedScopes?.length > 0
-              "
-              class="text-c-3 hover:bg-b-2 hover:text-c-1 rounded px-1.5"
-              size="sm"
-              @click.stop="deselectAllScopes">
-              Deselect All
+              @click.stop="toggleAllScopes">
+              {{ isAllSelected ? 'Deselect All' : 'Select All' }}
             </ScalarButton>
             <ScalarIcon
               class="text-c-3 group-hover/scopes-accordion:text-c-2"


### PR DESCRIPTION
This pull request adds the functionality for the "Deselect All" feature for the scopes selection in Oauth2 on the API Client. When the "Select All" button is clicked, or all scopes are manually selected, then the "Deselect All" button will appear and can be used to deselect all scopes.

Before:
<img width="568" height="582" alt="ScalarIssue9Pre" src="https://github.com/user-attachments/assets/b7783cfb-5d78-4de1-9840-f8e54088bc87" />

After:
<img width="584" height="667" alt="ScalarIssue9Post" src="https://github.com/user-attachments/assets/a7135a7f-5fe3-4ae6-b2d0-ea9a22333d11" />

[Video Demo](https://youtu.be/_isNi8ohwKE?si=SP5IdsUl_Ss0PIU2)

Resolves #14 
