### PR TITLE
Feat/add clear address history btn

### DIFF
--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -56,7 +56,6 @@ function handleClearHistory() {
       :target="target">
       <!-- History -->
       <MenuButton
-        v-if="history?.length"
         class="address-bar-history-button z-context-plus text-c-3 focus:text-c-1 relative mr-1 rounded-lg p-1.5">
         <ScalarIcon
           icon="History"
@@ -84,35 +83,52 @@ function handleClearHistory() {
         </div>
 
         <!-- History Item -->
-        <MenuItems
-          class="custom-scroll grid max-h-[inherit] grid-cols-[44px_1fr_repeat(3,auto)] items-center border-t p-0.75"
-          static
-          :style="{ width }">
-          <MenuItem
-            v-for="(entry, index) in history"
-            :key="entry.timestamp"
-            as="button"
-            class="font-code ui-active:*:bg-b-2 text-c-2 contents text-sm font-medium *:flex *:h-8 *:cursor-pointer *:items-center *:rounded-none *:px-1.5 *:first:rounded-l *:last:rounded-r"
-            :value="index"
-            @click="handleHistoryClick(entry)">
-            <HttpMethod
-              v-if="entry.response.method"
-              class="text-[11px]"
-              :method="entry.response.method" />
-            <div class="min-w-0">
-              <div class="text-c-1 min-w-0 truncate">
-                {{ entry.response.path }}
+        <div v-if="history?.length">
+          <MenuItems
+            class="custom-scroll grid max-h-[inherit] grid-cols-[44px_1fr_repeat(3,auto)] items-center border-t p-0.75"
+            static
+            :style="{ width }">
+            <MenuItem
+              v-for="(entry, index) in history"
+              :key="entry.timestamp"
+              as="button"
+              class="font-code ui-active:*:bg-b-2 text-c-2 contents text-sm font-medium *:flex *:h-8 *:cursor-pointer *:items-center *:rounded-none *:px-1.5 *:first:rounded-l *:last:rounded-r"
+              :value="index"
+              @click="handleHistoryClick(entry)">
+              <HttpMethod
+                v-if="entry.response.method"
+                class="text-[11px]"
+                :method="entry.response.method" />
+              <div class="min-w-0">
+                <div class="text-c-1 min-w-0 truncate">
+                  {{ entry.response.path }}
+                </div>
               </div>
-            </div>
-            <div>{{ formatMs(entry.response.duration) }}</div>
-            <div :class="[getStatusCodeColor(entry.response.status).color]">
-              {{ entry.response.status }}
-            </div>
-            <div>
-              {{ httpStatusCodes[entry.response.status]?.name }}
-            </div>
-          </MenuItem>
-        </MenuItems>
+              <div>{{ formatMs(entry.response.duration) }}</div>
+              <div :class="[getStatusCodeColor(entry.response.status).color]">
+                {{ entry.response.status }}
+              </div>
+              <div>
+                {{ httpStatusCodes[entry.response.status]?.name }}
+              </div>
+            </MenuItem>
+          </MenuItems>
+        </div>
+        <!-- Empty State -->
+        <div
+          v-else
+          class="text-c-3 flex flex-col items-center gap-2 p-4 text-center text-sm"
+          :style="{ width }">
+          <ScalarIcon
+            icon="History"
+            size="lg"
+            class="opacity-50" />
+          <div>
+            <div class="text-c-2 font-medium">No request history</div>
+            <div class="text-xs">Make a request to see it appear here</div>
+          </div>
+        </div>
+
         <ScalarFloatingBackdrop
           class="-top-(--scalar-address-bar-height) rounded-lg" />
       </template>

--- a/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
+++ b/packages/api-client/src/components/AddressBar/AddressBarHistory.vue
@@ -20,8 +20,8 @@ const { operation, target } = defineProps<{
   /** The id of the target to use for the popover (e.g. address bar) */
   target: string
 }>()
-
-const { requestHistory } = useWorkspace()
+// look here
+const { requestHistory, clearRequestHistory } = useWorkspace()
 
 /** Use a local copy to prevent mutation of the reactive object */
 const history = computed(() =>
@@ -38,6 +38,12 @@ function handleHistoryClick(requestHistoryItem: RequestEvent) {
   )
   // TODO: Restore the request data with the history item
   // TODO: Restore the response data with the history item
+}
+
+function handleClearHistory() {
+  if (confirm('Are you sure you want to clear the request history?')) {
+    clearRequestHistory()
+  }
 }
 </script>
 <template>
@@ -62,6 +68,21 @@ function handleHistoryClick(requestHistoryItem: RequestEvent) {
       <template
         v-if="open"
         #floating="{ width }">
+        <!-- Clear History Button -->
+        <div
+          v-if="history?.length"
+          class="border-b border-b-3 p-2"
+          :style="{ width }">
+          <button
+            class="text-c-3 hover:text-c-1 hover:bg-b-2 flex w-full items-center gap-2 rounded px-2 py-1 text-sm"
+            @click="handleClearHistory">
+            <ScalarIcon
+              icon="Trash"
+              size="sm" />
+            Clear History
+          </button>
+        </div>
+
         <!-- History Item -->
         <MenuItems
           class="custom-scroll grid max-h-[inherit] grid-cols-[44px_1fr_repeat(3,auto)] items-center border-t p-0.75"

--- a/packages/api-client/src/store/store.ts
+++ b/packages/api-client/src/store/store.ts
@@ -1,3 +1,9 @@
+import { useModal } from '@scalar/components'
+import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
+import type { Path, PathValue } from '@scalar/object-utils/nested'
+import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
+import { inject, reactive, ref, toRaw, type InjectionKey } from 'vue'
+
 import { createStoreCollections, extendedCollectionDataFactory } from '@/store/collections'
 import { createStoreCookies } from '@/store/cookies'
 import { createStoreEnvironments, extendedEnvironmentDataFactory } from '@/store/environment'
@@ -10,11 +16,6 @@ import { createStoreServers, extendedServerDataFactory } from '@/store/servers'
 import type { StoreContext } from '@/store/store-context'
 import { createStoreTags, extendedTagDataFactory } from '@/store/tags'
 import { createStoreWorkspaces, extendedWorkspaceDataFactory } from '@/store/workspace'
-import { useModal } from '@scalar/components'
-import type { RequestEvent, SecurityScheme } from '@scalar/oas-utils/entities/spec'
-import type { Path, PathValue } from '@scalar/object-utils/nested'
-import type { ApiReferenceConfiguration } from '@scalar/types/api-reference'
-import { type InjectionKey, inject, reactive, ref, toRaw } from 'vue'
 
 export type UpdateScheme = <P extends Path<SecurityScheme>>(
   path: P,
@@ -101,6 +102,11 @@ export const createWorkspaceStore = ({
   // OTHER HELPER DATA
   /** Running request history list */
   const requestHistory = reactive<RequestEvent[]>([])
+
+  /** Clear all request history */
+  const clearRequestHistory = () => {
+    requestHistory.splice(0, requestHistory.length)
+  }
 
   const { importSpecFile, importSpecFromUrl } = importSpecFileFactory(storeContext)
 
@@ -203,6 +209,7 @@ export const createWorkspaceStore = ({
       delete: deleteRequestExample,
     },
     requestHistory,
+    clearRequestHistory,
     securitySchemeMutators: {
       ...securitySchemeMutators,
       rawAdd: securitySchemeMutators.add,


### PR DESCRIPTION
Adds a clear address history button to the API Client history dropdown, and provides a default "no history" display if the button is clicked and there is no history to display.

Before the feature:
<img width="757" height="200" alt="ScalarIssue17Pre" src="https://github.com/user-attachments/assets/34bee36c-2493-428f-81e2-d7ee78887e51" />

After the feature:
<img width="787" height="224" alt="ScalarIssue17Post" src="https://github.com/user-attachments/assets/55a2a9dd-11af-4c56-8ea7-4cf2430d8b71" />
<img width="780" height="165" alt="ScalarIssue17Post2" src="https://github.com/user-attachments/assets/98d1b136-5e95-4196-ac84-37e2ead917ed" />

[Demo](https://youtu.be/trrOx9VY0N4?si=Ne5BGjd9M9ibuq1P)

Resolves #26 
